### PR TITLE
Improve dev docs and fix PDF viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Running the project locally
+
+1. Install Node.js (version 18 or newer).
+2. Run `npm install --legacy-peer-deps` to install dependencies.
+3. Start the dev server with `npm run dev`.
+4. Visit `http://localhost:5173` in your browser. The server proxies API requests to `http://localhost:5212` as defined in `vite.config.ts`.
+5. For a production build, run `npm run build` and then `npm run preview` to preview it locally.
+
+### 中文指南
+
+1. 安装 Node.js（建议 18 及以上版本）。
+2. 执行 `npm install --legacy-peer-deps` 安装依赖。
+3. 运行 `npm run dev` 启动开发服务器。
+4. 在浏览器打开 `http://localhost:5173` 查看项目效果，开发服务器会按照 `vite.config.ts` 的配置代理到 `http://localhost:5212`。
+5. 使用 `npm run build` 构建生产版本，随后通过 `npm run preview` 在本地预览。
+
+

--- a/public/pdfviewer.html
+++ b/public/pdfviewer.html
@@ -28,14 +28,14 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="google" content="notranslate">
     <title>PDF.js viewer</title>
 
-    <link rel="resource" type="application/l10n" href="assets/pdfjs/locale/locale.json">
+    <link rel="resource" type="application/l10n" href="/assets/pdfjs/locale/locale.json">
 
     <!-- This snippet is used in production (included from viewer.html) -->
-    <script src="assets/pdfjs/pdf.mjs" type="module"></script>
+    <script src="/assets/pdfjs/pdf.mjs" type="module"></script>
 
-    <link rel="stylesheet" href="assets/pdfjs/viewer.css">
+    <link rel="stylesheet" href="/assets/pdfjs/viewer.css">
 
-    <script src="assets/pdfjs/viewer.mjs" type="module"></script>
+    <script src="/assets/pdfjs/viewer.mjs" type="module"></script>
 </head>
 
 <body tabindex="0">


### PR DESCRIPTION
## Summary
- fix PDF viewer asset paths so dev server starts
- document dev environment steps in both English and Chinese

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run dev` *(starts Vite dev server successfully)*
- `npm run build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68849c769bf4832190ae0d8621f29834